### PR TITLE
Use `webext-dynamic-content-scripts` to handle additional permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ Bitbucket's code viewer UI has changed greatly, so there is still lots of work t
 
 ## Get your private site works
 
-If GitHub/GitLab/Bitbucket you are using is hosted on different site, go to chrome://extensions, click options of Octohint, then add [match patterns](https://developer.chrome.com/extensions/match_patterns) of your site, like `https://www.example.com/*`.
-
-<img src="assets/options.png" alt="options" width="422">
+If you're self-hosting GitHub/GitLab/Bitbucket (Enterprise, Community, etc), visit your site, right-click on Octohint's icon in the toolbar and select **Enable Octohint on this domain.**
 
 ## Privacy policy
 

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -18,7 +18,7 @@
     "https://bitbucket.org/*",
     "storage",
     "contextMenus",
-		"activeTab"
+    "activeTab"
   ],
   "optional_permissions": ["<all_urls>"],
   "browser_action": {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -17,7 +17,8 @@
     "https://gitlab.com/*",
     "https://bitbucket.org/*",
     "storage",
-    "contextMenus"
+    "contextMenus",
+		"activeTab"
   ],
   "optional_permissions": ["<all_urls>"],
   "browser_action": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "typescript": "^3.8.3",
     "vscode-css-languageservice": "^4.1.1",
     "vscode-languageserver-types": "^3.15.1",
-    "webext-domain-permission-toggle": "^1.0.1",
-    "webext-dynamic-content-scripts": "^6.0.4"
+    "webext-domain-permission-toggle": "^2.1.0",
+    "webext-dynamic-content-scripts": "^7.1.0"
   },
   "devDependencies": {
     "awesome-typescript-loader": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "typescript": "^3.8.3",
     "vscode-css-languageservice": "^4.1.1",
     "vscode-languageserver-types": "^3.15.1",
-    "webext-domain-permission-toggle": "^1.0.0"
+    "webext-domain-permission-toggle": "^1.0.1",
+    "webext-dynamic-content-scripts": "^6.0.4"
   },
   "devDependencies": {
     "awesome-typescript-loader": "^5.2.1",

--- a/src/chrome/background.ts
+++ b/src/chrome/background.ts
@@ -1,44 +1,4 @@
-import addDomainPermissionToggle from 'webext-domain-permission-toggle'
-addDomainPermissionToggle()
+import 'webext-dynamic-content-scripts';
+import addDomainPermissionToggle from 'webext-domain-permission-toggle';
 
-async function inject(tabId: number) {
-  console.log('injecting...')
-  const { ChromeAdapter } = await import('./adapter')
-  new ChromeAdapter()
-
-  chrome.tabs.executeScript(tabId, { file: 'dist/content-script.js' }, () => {
-    console.log('injected')
-  })
-}
-
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  // console.log('tabs.onUpdate', tabId, changeInfo, tab)
-
-  if (changeInfo.status === 'complete') {
-    chrome.tabs.executeScript(
-      tabId,
-      {
-        code: 'var injected = window.octohintInjected; window.octohintInjected = true; injected;',
-      },
-      res => {
-        if (!chrome.runtime.lastError && !res[0]) {
-          inject(tabId)
-        }
-      },
-    )
-  }
-})
-
-// Need to request all sites permissions to get URL
-// So it does work as expected
-
-// chrome.browserAction.onClicked.addListener(tab => {
-//   if (!tab.url) return
-//   const { protocol, host } = new URL(tab.url)
-//   const origins = [protocol + '//' + host + '/*']
-//   console.log(origins)
-//   chrome.permissions.request({ origins }, granted => {
-//     console.log(granted)
-//     if (!granted) return
-//   })
-// })
+addDomainPermissionToggle();

--- a/src/chrome/background.ts
+++ b/src/chrome/background.ts
@@ -1,4 +1,3 @@
 import 'webext-dynamic-content-scripts'
 import addDomainPermissionToggle from 'webext-domain-permission-toggle'
-
 addDomainPermissionToggle()

--- a/src/chrome/background.ts
+++ b/src/chrome/background.ts
@@ -1,4 +1,4 @@
-import 'webext-dynamic-content-scripts';
-import addDomainPermissionToggle from 'webext-domain-permission-toggle';
+import 'webext-dynamic-content-scripts'
+import addDomainPermissionToggle from 'webext-domain-permission-toggle'
 
-addDomainPermissionToggle();
+addDomainPermissionToggle()


### PR DESCRIPTION
I saw you were using [webext-domain-permission-toggle](https://github.com/fregante/webext-domain-permission-toggle) so I opened this PR to add its companion [webext-dynamic-content-scripts](https://github.com/fregante/webext-dynamic-content-scripts) following the [integration guide](https://github.com/fregante/webext-dynamic-content-scripts/blob/master/how-to-add-github-enterprise-support-to-web-extensions.md).